### PR TITLE
Task creation fails for PR events when branch base is older than 2019-11-05

### DIFF
--- a/config/roles.yml
+++ b/config/roles.yml
@@ -51,7 +51,7 @@
     * Treeherder access only to the dedicated tree, servo-prs
   scopes:
     - assume:project:servo:decision-task/base
-    - queue:create-task:medium:proj-servo/docker-untrusted
+    - queue:create-task:medium:proj-servo/servo-docker-untrusted
     - queue:route:tc-treeherder-staging.v2._/servo-prs.*
     - queue:route:tc-treeherder.v2._/servo-prs.*
 


### PR DESCRIPTION
The following scopes are missing when trying to create an untrusted task in a PR in servo/servo right now:
```
{
  "AnyOf": [
    {
      "AnyOf": [
        "queue:create-task:highest:aws-provisioner-v1/servo-docker-untrusted",
        "queue:create-task:very-high:aws-provisioner-v1/servo-docker-untrusted",
        "queue:create-task:high:aws-provisioner-v1/servo-docker-untrusted",
        "queue:create-task:medium:aws-provisioner-v1/servo-docker-untrusted",
        "queue:create-task:low:aws-provisioner-v1/servo-docker-untrusted",
        "queue:create-task:very-low:aws-provisioner-v1/servo-docker-untrusted",
        "queue:create-task:lowest:aws-provisioner-v1/servo-docker-untrusted"
      ]
    },
    {
      "AnyOf": [
        "queue:create-task:aws-provisioner-v1/servo-docker-untrusted",
        {
          "AllOf": [
            "queue:define-task:aws-provisioner-v1/servo-docker-untrusted",
            "queue:task-group-id:taskcluster-github/CRJtbx1GT9ulfXgLfF4gFA",
            "queue:schedule-task:taskcluster-github/CRJtbx1GT9ulfXgLfF4gFA/CRJtbx1GT9ulfXgLfF4gFA"
          ]
        }
      ]
    }
  ]
}
```
As far as I can tell, updating the name should fix it?