### PR TITLE
Install Homebrew in /usr/local through Salt

### DIFF
--- a/salt/macos.sls
+++ b/salt/macos.sls
@@ -106,3 +106,19 @@ net.generic.worker:
     - enable: True
     - watch:
       - file: /Library/LaunchDaemons/net.generic.worker.plist
+
+/usr/local:
+  file.directory:
+    - user: {{ user }}
+    - mode: 755
+
+Homebrew:
+  cmd.run:
+    - runas: {{ user }}
+    - creates: /usr/local/bin/brew
+    - require:
+        - /usr/local
+    - name: >-
+        curl -L https://github.com/Homebrew/brew/tarball/master |
+            tar xz --strip 1 -C /usr/local &&
+        brew update

--- a/salt/macos.sls
+++ b/salt/macos.sls
@@ -65,7 +65,7 @@ sshkeys:
     - formatter: json
     - dataset:
         provisionerId: proj-servo
-        workerType: {{ "macos-disabled-" + grains.id if pillar.disabled else "macos" }}
+        workerType: {{ pillar.worker_type }}{{ "-disabled-" + grains.id if pillar.disabled else "" }}
         workerGroup: proj-servo
         workerId: {{ grains.id }}
         tasksDir: {{ home }}/tasks

--- a/salt/macos.sls
+++ b/salt/macos.sls
@@ -1,4 +1,4 @@
-{% set bin = "/usr/local/bin" %}
+{% set bin = "/opt/local/bin" %}
 {% set etc = "/etc/generic-worker" %}
 {% set user = "worker" %}
 {% set home = "/Users/" + user %}

--- a/salt/pillar/external_data.py
+++ b/salt/pillar/external_data.py
@@ -19,11 +19,16 @@ def ext_pillar(minion_id, _pillar, *_args):
             "simonsapin",
         ]]
 
-        CACHE["workers"] = read_yaml("worker-pools.yml")["macos"]["workers"]
+        CACHE["workers"] = {
+            worker: (pool_name, config)
+            for pool_name, pool in read_yaml("worker-pools.yml").items()
+            if pool["kind"] == "static"
+            for worker, config in pool["workers"].items()
+        }
 
-    worker = CACHE["workers"][minion_id]
-    disabled = {"disabled": True, None: False}[worker]
-    return dict(disabled=disabled, **CACHE)
+    pool_name, config = CACHE["workers"][minion_id]
+    disabled = {"disabled": True, None: False}[config]
+    return dict(disabled=disabled, worker_type=pool_name, **CACHE)
 
 
 def read_yaml(filename):

--- a/salt/roster/custom.py
+++ b/salt/roster/custom.py
@@ -3,10 +3,15 @@ import yaml
 
 
 def roster():
+    workers = {}
     pools = os.path.join(os.path.dirname(__file__), "..", "..", "config", "worker-pools.yml")
-    pool = yaml.safe_load(open(pools))["macos"]
-    hostname = pool["worker_hostname_template"]
-    return {w: hostname.format(id=w) for w in pool["workers"]}
+    for name, pool in yaml.safe_load(open(pools)).items():
+        if pool["kind"] == "static":
+            hostname = pool["worker_hostname_template"]
+            for w in pool["workers"]:
+                assert w not in workers
+                workers[w] = hostname.format(id=w)
+    return workers
 
 
 # Custom roster modules are unfortunately not documented.


### PR DESCRIPTION
The directory is owned by user `worker` which also runs generic-worker, so that tasks can run Homebrew and install things.

The location change makes generic-worker restart which makes any running task fail, so this is better deployed while Homu’s queue is empty.